### PR TITLE
Update to latest KiCAD 6.0 release.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -134,7 +134,7 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
 
     def Run(self):
         board = pcbnew.GetBoard()
-        modules = board.GetModules()
+        modules = board.GetFootprints() # was GetModules() but this does not work with KiCAD 6.0
 
         fn = Path(board.GetFileName()).with_suffix("")
 

--- a/__init__.py
+++ b/__init__.py
@@ -135,6 +135,9 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
     def Run(self):
         board = pcbnew.GetBoard()
         modules = board.GetFootprints() # was GetModules() but this does not work with KiCAD 6.0
+        origin = board.GetDesignSettings().GetAuxOrigin()
+        origin_x = Decimal(origin.x) / Decimal(1000000)
+        origin_y = Decimal(origin.y) / Decimal(-1000000)
 
         fn = Path(board.GetFileName()).with_suffix("")
 
@@ -192,8 +195,8 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
                     print(f"rotating {ref} ({footprint}): prev {rot}, new {new_rot}")
                     rot = new_rot
 
-            x = str(mid_x) + "mm"
-            y = str(mid_y) + "mm"
+            x = str(mid_x - origin_x) + "mm"
+            y = str(mid_y - origin_y) + "mm"
 
             if layer == "F.Cu":
                 topw.writerow([ref, x, y, "top", rot])

--- a/bom2jlc.py
+++ b/bom2jlc.py
@@ -13,7 +13,7 @@ ref_ignore = ["TP", "T", "NT", "REF***", "G", "H"]
 def parse_pcb(fn):
     pcb_fn = str(Path(fn).with_suffix("")) + ".kicad_pcb"
     board = pcbnew.LoadBoard(pcb_fn)
-    modules = board.GetModules()
+    modules = board.GetFootprints() # was GetModules() but this does not work with KiCAD 6.0
 
     for mod in modules:
         ref = mod.GetReference()


### PR DESCRIPTION
The current version fails with the recent KiCAD 6.0 release since GetModules() is depreceated, and no longer available.